### PR TITLE
Fix and clarify Cybrary evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,28 @@ Welcome to my Cybrary IT & Cybersecurity Foundations learning journey! This repo
 
 ## Certificates
 
-| Course Name                           | Completion Date |
+| Course Name                           | Completion Date (ISO) |
 | ----------------------------------- | --------------- |
-| [Vulnerability Scanner Basics](./Certificates/cybrary-cert-vulnerability-scanner-basics.pdf)  | 16/08/2024      |
-| [Cryptography Basics](./Certificates/cybrary-cert-cryptography-basics.pdf)             | 15/10/2024      |
-| [Patching Basics](./Certificates/cybrary-cert-patching-basics.pdf)                 | 15/10/2024      |
-| [Group Policy Basics](./Certificates/cybrary-cert-group-policy-basics.pdf)             | 16/10/2024      |
-| [IP Addressing Basics](./Certificates/cybrary-cert-ip-addressing-basics.pdf)            | 24/10/2024      |
-| [Firewall Basics](./Certificates/cybrary-cert-firewall-basics.pdf)                 | 24/10/2024      |  
-| [Access Control Basics](./Certificates/cybrary-cert-access-control-basics.pdf)       | 01/08/2025      |
-| [Data Backup and Recovery Basics](./Certificates/cybrary-cert-data-backup-and-recovery.pdf)  | 07/02/2025      |
-| [Threat Modeling](./Certificates/cybrary-cert-threat-modeling.pdf)  | 10/02/2025      | 
+| [Vulnerability Scanner Basics](./Certificates/cybrary-cert-vulnerability-scanner-basics.pdf)  | 2024-08-16      |
+| [Cryptography Basics](./Certificates/cybrary-cert-cryptography-basics.pdf)             | 2024-10-15      |
+| [Patching Basics](./Certificates/cybrary-cert-patching-basics.pdf)                 | 2024-10-15      |
+| [Group Policy Basics](./Certificates/cybrary-cert-group-policy-basics.pdf)             | 2024-10-16      |
+| [IP Addressing Basics](./Certificates/cybrary-cert-ip-addressing-basics.pdf)            | 2024-10-24      |
+| [Firewall Basics](./Certificates/cybrary-cert-firewall-basics.pdf)                 | 2024-10-24      |  
+| [Access Control Basics](./Certificates/cybrary-cert-access-control-basics.pdf)       | 2025-08-01      |
+| [Data Backup and Recovery Basics](./Certificates/cybrary-cert-data-backup-and-recovery.pdf)  | 2025-02-07      |
+| [Threat Modeling](./Certificates/cybrary-cert-threat-modeling.pdf)  | 2025-02-10      | 
 
 
-| Lab Name                         | Completion Date |
+| Lab Name                         | Completion Date (ISO) |
 | ----------------------------------- | --------------- |
-| [Security+: General Security Concepts](./Labs/cybrary-cert-security-general-security-concepts.pdf)             | 13/08/2024      |
-| [Security+: Threats, Vulnerabilities and Mitigations](./Labs/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf)             | 13/08/2024      |
-| [Security+: Security Architecture](./Labs/cybrary-cert-security-security-architecture.pdf)                 | 19/08/2024      |
-| [Security+: Security Operations](./Labs/cybrary-cert-security-security-operations.pdf)            | 18/09/2024      |
-| [Security+: Security Program Management and Oversight](./Labs/cybrary-cert-security-security-program-management-and-oversight.pdf)           | 15/10/2024      |
-| [Defensive Security Operations](./Labs/cybrary-cert-defensive-security-operations.pdf)           | 07/02/2025      |
-| [Defensive Security and Cyber Risk](./Labs/cybrary-cert-defensive-security-and-cyber-risk.pdf)  | 10/02/2025      | 
+| [Security+: General Security Concepts](./Labs/cybrary-cert-security-general-security-concepts.pdf)             | 2024-08-13      |
+| [Security+: Threats, Vulnerabilities and Mitigations](./Labs/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf)             | 2024-08-13      |
+| [Security+: Security Architecture](./Labs/cybrary-cert-security-security-architecture.pdf)                 | 2024-08-19      |
+| [Security+: Security Operations](./Labs/cybrary-cert-security-security-operations.pdf)            | 2024-09-18      |
+| [Security+: Security Program Management and Oversight](./Labs/cybrary-cert-security-security-program-management-and-oversight.pdf)           | 2024-10-15      |
+| [Defensive Security Operations](./Labs/cybrary-cert-defensive-security-operations.pdf)           | 2025-02-07      |
+| [Defensive Security and Cyber Risk](./Labs/cybrary-cert-defensive-security-and-cyber-risk.pdf)  | 2025-02-10      | 
 
 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Welcome to my Cybrary IT & Cybersecurity Foundations learning journey! This repo
 - 🔹 Learn, Practice, Prove – Engaging in courses, labs, and challenges to build practical skills.
 - 🔹 Hands-On Experience – Working with real security tools and live environments.
 - 🔹 Tracking Progress – Using Cybrary's Skills Tracker to measure growth.
-- 🔹 Sharing Achievements – Earning digital badges from Cybrary & Credly.
+- 🔹 Preserving Evidence – Linking course and lab completion PDFs for direct review.
 
 ## 🤝 Why Cybrary?
 Cybrary’s interactive courses provide real-world cybersecurity training, equipping me with in-demand skills and preparing me for industry certifications.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,9 @@ Cybrary’s interactive courses provide real-world cybersecurity training, equip
 
 This repository reflects my personal learning journey, highlighting my projects, certifications, and continuous growth in cybersecurity.
 
-## 📌 Stay tuned for more updates!
+## Evidence Scope
 
-This update enhances readability, structure, and professionalism while making it visually appealing. Let me know if you want any refinements! 🚀
-
----
-
-_This README reflects my personal learning journey, highlighting projects and certifications._
+This repository contains course and lab completion PDFs. It documents personal training progress and does not include course solutions or claim professional cybersecurity experience.
 
 
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Welcome to my Cybrary IT & Cybersecurity Foundations learning journey! This repo
 
 ## 🚀 My Learning Highlights
 - 🔹 Learn, Practice, Prove – Engaging in courses, labs, and challenges to build practical skills.
-- 🔹 Hands-On Experience – Working with real security tools and live environments.
+- 🔹 Guided Practice – Working through platform labs and structured security exercises.
 - 🔹 Tracking Progress – Using Cybrary's Skills Tracker to measure growth.
 - 🔹 Preserving Evidence – Linking course and lab completion PDFs for direct review.
 
 ## 🤝 Why Cybrary?
-Cybrary’s interactive courses provide real-world cybersecurity training, equipping me with in-demand skills and preparing me for industry certifications.
+Cybrary’s interactive courses support my study of cybersecurity foundations and defensive concepts through guided training.
 
 This repository reflects my personal learning journey, highlighting my projects, certifications, and continuous growth in cybersecurity.
 

--- a/README.md
+++ b/README.md
@@ -72,5 +72,9 @@ This repository reflects my personal learning journey, highlighting my projects,
 
 This repository contains course and lab completion PDFs. It documents personal training progress and does not include course solutions or claim professional cybersecurity experience.
 
+## Related Portfolio
+
+[View the full certifications and learning journey](https://jimblogic.github.io/#certifications).
+
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Welcome to my Cybrary IT & Cybersecurity Foundations learning journey! This repo
 
 
 
-# 🎯 Skills & Knowledge Gained
-## 🖥 Operating System & Security Basics
+## 🎯 Skills & Knowledge Gained
+### 🖥 Operating System & Security Basics
 - ✅ Windows & Linux CLI Basics
 - ✅ Group Policy & Active Directory
 - ✅ Vulnerability Scanning & Patching
@@ -40,20 +40,20 @@ Welcome to my Cybrary IT & Cybersecurity Foundations learning journey! This repo
 - ✅ Data Backup & Recovery
 - ✅ Threat Modeling & Risk Assessment
 
-## 🌍 Networking & Security
+### 🌍 Networking & Security
 - ✅ IP Addressing & Subnetting
 - ✅ Network Reference Models (OSI & TCP/IP)
 - ✅ VPNs & Secure Network Configurations
 - ✅ Wireshark & Nmap Basics
 - ✅ Network Troubleshooting
 
-## 🛡 Cybersecurity & Defensive Operations
+### 🛡 Cybersecurity & Defensive Operations
 - ✅ Incident Response & Threat Detection
 - ✅ Cryptography (Symmetric & Asymmetric, Hashing)
 - ✅ Least Privilege & Access Control
 - ✅ Security Architecture & Hardening
 
-## 💻 Programming & Automation
+### 💻 Programming & Automation
 - ✅ Bash Scripting & PowerShell
 - ✅ Python for Security & Automation
 

--- a/README.md
+++ b/README.md
@@ -5,28 +5,28 @@ Welcome to my Cybrary IT & Cybersecurity Foundations learning journey! This repo
 
 ## Certificates
 
-| Coursae Name                           | Completion Date |
+| Course Name                           | Completion Date |
 | ----------------------------------- | --------------- |
-| [Vulnerability Scanner Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf)  | 16/08/2024      |
-| [Cryptography Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-cryptography-basics.pdf)             | 15/10/2024      |
-| [Patching Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-patching-basics.pdf)                 | 15/10/2024      |
-| [Group Policy Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-group-policy-basics.pdf)             | 16/10/2024      |
-| [IP Addressing Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-ip-addressing-basics.pdf)            | 24/10/2024      |
-| [Firewall Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-firewall-basics.pdf)                 | 24/10/2024      |  
-| [Access Control Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Certificates/cybrary-cert-access-control-basics.pdf)       | 01/08/2025      |
-| [Data Backup and Recovery Basics](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations-Certificates/blob/main/Certificates/cybrary-cert-data-backup-and-recovery.pdf)  | 07/02/2025      |
-| [Threat Modeling](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations-Certificates/blob/main/Certificates/cybrary-cert-threat-modeling.pdf)  | 10/02/2025      | 
+| [Vulnerability Scanner Basics](./Certificates/cybrary-cert-vulnerability-scanner-basics.pdf)  | 16/08/2024      |
+| [Cryptography Basics](./Certificates/cybrary-cert-cryptography-basics.pdf)             | 15/10/2024      |
+| [Patching Basics](./Certificates/cybrary-cert-patching-basics.pdf)                 | 15/10/2024      |
+| [Group Policy Basics](./Certificates/cybrary-cert-group-policy-basics.pdf)             | 16/10/2024      |
+| [IP Addressing Basics](./Certificates/cybrary-cert-ip-addressing-basics.pdf)            | 24/10/2024      |
+| [Firewall Basics](./Certificates/cybrary-cert-firewall-basics.pdf)                 | 24/10/2024      |  
+| [Access Control Basics](./Certificates/cybrary-cert-access-control-basics.pdf)       | 01/08/2025      |
+| [Data Backup and Recovery Basics](./Certificates/cybrary-cert-data-backup-and-recovery.pdf)  | 07/02/2025      |
+| [Threat Modeling](./Certificates/cybrary-cert-threat-modeling.pdf)  | 10/02/2025      | 
 
 
 | Lab Name                         | Completion Date |
 | ----------------------------------- | --------------- |
-| [Security+: General Security Concepts](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Labs/cybrary-cert-security-general-security-concepts.pdf)             | 13/08/2024      |
-| [Security+: Threats, Vulnerabilities and Mitigations](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Labs/cybrary-cert-vulnerability-scanner-basics.pdf)             | 13/08/2024      |
-| [Security+: Security Architecture](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Labs/cybrary-cert-security-security-architecture.pdf)                 | 19/08/2024      |
-| [Security+: Security Operations](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Labs/cybrary-cert-security-security-operations.pdf)            | 18/09/2024      |
-| [Security+: Security Program Management and Oversight](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations--Certificates/blob/main/Labs/cybrary-cert-security-security-program-management-and-oversight.pdf)           | 15/10/2024      |
-| [Defensive Security Operations](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations-Certificates/blob/main/Labs/cybrary-cert-defensive-security-operations.pdf)           | 07/02/2025      |
-| [Defensive Security and Cyber Risk](https://github.com/JimBLogic/Cybrary-IT-and-Cybersecurity-Foundations-Certificates/blob/main/Labs/cybrary-cert-defensive-security-and-cyber-risk.pdf)  | 10/02/2025      | 
+| [Security+: General Security Concepts](./Labs/cybrary-cert-security-general-security-concepts.pdf)             | 13/08/2024      |
+| [Security+: Threats, Vulnerabilities and Mitigations](./Labs/cybrary-cert-security-threats-vulnerabilities-and-mitigations.pdf)             | 13/08/2024      |
+| [Security+: Security Architecture](./Labs/cybrary-cert-security-security-architecture.pdf)                 | 19/08/2024      |
+| [Security+: Security Operations](./Labs/cybrary-cert-security-security-operations.pdf)            | 18/09/2024      |
+| [Security+: Security Program Management and Oversight](./Labs/cybrary-cert-security-security-program-management-and-oversight.pdf)           | 15/10/2024      |
+| [Defensive Security Operations](./Labs/cybrary-cert-defensive-security-operations.pdf)           | 07/02/2025      |
+| [Defensive Security and Cyber Risk](./Labs/cybrary-cert-defensive-security-and-cyber-risk.pdf)  | 10/02/2025      | 
 
 
 


### PR DESCRIPTION
## Summary
- repair 16 certificate and lab links that referenced obsolete repository names or crossed files
- correct the `Coursae` typo
- remove public README drafting residue and the empty `Stay tuned` section
- add an evidence-scope note clarifying training completion rather than course solutions or professional experience
- replace the unsupported Credly-badge claim with verifiable PDF evidence
- standardize all 16 completion dates to ISO `YYYY-MM-DD`
- fix the Markdown outline to use one H1 and correctly nested sections
- recalibrate `live environments` and `in-demand skills` as guided platform practice and foundation study
- add a contextual route from the evidence repository to the portfolio certification journey

## Why
Recruiters can open every stored PDF, navigate an accessible evidence-based junior learning record, and continue naturally to the main portfolio without template residue, unsupported claims, ambiguous dates, or social-link clutter.

## Validation
- confirmed all 16 linked PDFs exist and use valid relative paths
- confirmed drafting residue, unsupported Credly language, and inflated training claims are absent
- confirmed 16 ISO dates and zero slash-formatted dates
- confirmed heading structure: one H1, six H2s, four H3s
- confirmed the portfolio certification link appears exactly once
- compared with `main`: seven focused commits, one modified file, zero commits behind